### PR TITLE
Add TutorialSearch to Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - [Learing pathways for testers](https://www.awesome-testing.com/2016/03/learning-pathways-for-testers)
 - [Do's and don'ts for testers - 2016 edition](https://www.awesome-testing.com/2016/02/dos-and-donts-for-testers-2016-edition)
 - [Best Software Testing books #2](https://www.awesome-testing.com/2020/06/best-software-testing-books-2)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/software-testing) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 ## Performance
 - [Five minutes performance report with Google Lighthouse](https://www.awesome-testing.com/2018/03/five-minutes-performance-report-with)
 - [Measuring page load times using Selenium](https://www.awesome-testing.com/2019/01/measuring-page-load-times-using-selenium)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [Learing pathways for testers](https://www.awesome-testing.com/2016/03/learning-pathways-for-testers)
 - [Do's and don'ts for testers - 2016 edition](https://www.awesome-testing.com/2016/02/dos-and-donts-for-testers-2016-edition)
 - [Best Software Testing books #2](https://www.awesome-testing.com/2020/06/best-software-testing-books-2)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 ## Performance
 - [Five minutes performance report with Google Lighthouse](https://www.awesome-testing.com/2018/03/five-minutes-performance-report-with)
 - [Measuring page load times using Selenium](https://www.awesome-testing.com/2019/01/measuring-page-load-times-using-selenium)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Learning* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/software-testing) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/software-testing) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.